### PR TITLE
[mobcec-tool] clarify backend linter/test paths

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,13 +16,13 @@
 - Node dependencies for the frontend are installed with `npm install` inside `frontend/`.
 
 ## Linting and Tests
-- Run the backend linter with:
+- From `backend/` run the backend linter with:
 
   ```bash
   uv run bash scripts/lint.sh
   ```
 
-- Run backend tests with coverage using:
+- From `backend/` run backend tests with coverage using:
 
   ```bash
   uv run bash scripts/tests-start.sh


### PR DESCRIPTION
## Summary
- clarify that lint and test commands should run from within `backend/`

## Testing
- `uv run pre-commit run --files ../AGENTS.md`
- `uv run bash scripts/lint.sh`
- `uv run bash scripts/tests-start.sh` *(fails: connection refused to PostgreSQL)*

------
https://chatgpt.com/codex/tasks/task_b_686887ecc778832a9d29915f4463197e