### PR TITLE
[mobcec-tool] add commit signing guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,3 +50,8 @@
 - Follow the title format: `[<project_name>] <Title>`.
 - Ensure `pre-commit`, lints and tests pass before opening a PR.
 - Update or add tests for any changed code.
+
+## Commit Signing
+- All contributors must sign their commits. Use `git commit -S` to add a verified signature.
+- Consider enabling automatic commit signing in your Git configuration.
+- For more details, see GitHub's signing guide: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits


### PR DESCRIPTION
## Summary
- document how to sign commits and require signed commits

## Testing
- `uv run bash scripts/lint.sh` *(fails: would reformat)*
- `uv run pre-commit run --files ../AGENTS.md`
- `uv run bash scripts/tests-start.sh` *(fails: missing env vars)*

------
https://chatgpt.com/codex/tasks/task_b_686887f273f4832a89594e733900347a